### PR TITLE
Updated to work with ghc 7.10

### DIFF
--- a/blpapi.cabal
+++ b/blpapi.cabal
@@ -22,7 +22,7 @@ flag buildexamples
 library
     default-language: Haskell2010
     build-depends: base >=4.5, time >= 1.4 && < 1.5,
-                   MonadCatchIO-mtl >=0.3, mtl >=2.0,
+                   mtl >=2.0,
                    containers >=0.4 && <0.5, stm >=2.3,
                    text >= 0.11.1.0, bytestring >= 0.9.2.1
 
@@ -51,7 +51,7 @@ library
               blpapi_schema.h blpapi_service.h blpapi_session.h
               blpapi_sessionoptions.h blpapi_streamproxy.h
               blpapi_subscriptionlist.h blpapi_topic.h blpapi_topiclist.h
-              blpapi_types.h blpapi_versioninfo.h
+              blpapi_types.h 
     hs-source-dirs: src
     other-modules: Finance.Blpapi.Impl.ErrorImpl Finance.Blpapi.Impl.RequestImpl
                    Finance.Blpapi.Impl.CorrelationIdImpl Finance.Blpapi.Impl.DatetimeImpl

--- a/blpapi.cabal
+++ b/blpapi.cabal
@@ -1,5 +1,5 @@
 name: blpapi
-version: 0.1.0.0
+version: 0.1.0.1
 cabal-version: >=1.10
 build-type: Simple
 license: MIT
@@ -22,8 +22,8 @@ flag buildexamples
 library
     default-language: Haskell2010
     build-depends: base >=4.5, time >= 1.4 && < 1.5,
-                   MonadCatchIO-mtl >=0.3, mtl >=2.0,
-                   containers >=0.4 && <0.5, stm >=2.3,
+                   mtl >=2.0,
+                   containers >=0.4 && <0.6, stm >=2.3,
                    text >= 0.11.1.0, bytestring >= 0.9.2.1
 
     exposed-modules: Finance.Blpapi.ElementFormatter
@@ -51,7 +51,7 @@ library
               blpapi_schema.h blpapi_service.h blpapi_session.h
               blpapi_sessionoptions.h blpapi_streamproxy.h
               blpapi_subscriptionlist.h blpapi_topic.h blpapi_topiclist.h
-              blpapi_types.h blpapi_versioninfo.h
+              blpapi_types.h 
     hs-source-dirs: src
     other-modules: Finance.Blpapi.Impl.ErrorImpl Finance.Blpapi.Impl.RequestImpl
                    Finance.Blpapi.Impl.CorrelationIdImpl Finance.Blpapi.Impl.DatetimeImpl

--- a/src/Finance/Blpapi/ElementFormatter.hs
+++ b/src/Finance/Blpapi/ElementFormatter.hs
@@ -50,6 +50,7 @@ module Finance.Blpapi.ElementFormatter (
 import           Finance.Blpapi.Impl.ElementImpl
 import           Finance.Blpapi.Session
 
+import           Control.Applicative
 import           Control.Monad.State.Strict
 import           Finance.Blpapi.Impl.ErrorImpl
 
@@ -59,7 +60,7 @@ import           Finance.Blpapi.Request
 import qualified Finance.Blpapi.Types            as T
 
 import qualified Data.Text                       as Text
-import           Foreign                         hiding (unsafePerformIO)
+import           Foreign
 import           Foreign.C.String
 import           Foreign.C.Types
 
@@ -78,6 +79,14 @@ newtype ElementFormatter a = ElementFormatter {
 newtype ElementWritable = ElementWritable {
     getElementImpl :: Ptr ElementImpl
 }
+
+instance Functor ElementFormatter where
+    fmap = liftM
+
+instance Applicative ElementFormatter where
+    pure = formatterReturn
+    (<*>) = ap
+    
 
 -- | The monad instance
 instance Monad ElementFormatter where

--- a/src/Finance/Blpapi/Session.hs
+++ b/src/Finance/Blpapi/Session.hs
@@ -123,6 +123,7 @@ import           Finance.Blpapi.SessionOptions
 import           Finance.Blpapi.Subscription
 
 import           Control.Concurrent
+import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.RWS.Strict
 import           Control.Monad.State.Strict
@@ -176,6 +177,13 @@ data BlpapiState = BlpapiState {
       _blpapiCorrelationHandlerMap :: TVar CidHandlerMap,
       _blpapiServiceMap            :: ServiceMap
 }
+
+instance Functor Blpapi where
+    fmap = liftM
+
+instance Applicative Blpapi where
+    pure = blpapiReturn
+    (<*>) = ap
 
 instance Monad Blpapi where
     (>>=) = blpapiBind


### PR DESCRIPTION
In the next release of GHC, Applicative is becoming a superclass of
Monad. As such, any type which has a Monad instance but not an
Applicative instance will no longer compile. Because of this, an
Applicative instance has been added for the ElementFormatter and Blpapi
types.

See https://www.haskell.org/haskellwiki/Functor-Applicative-Monad_Proposal
for more information.
